### PR TITLE
[bssl] add support for CACHEC-INFO tls extension (RFC 7924)

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1133,6 +1133,79 @@ OPENSSL_EXPORT void SSL_CTX_set_private_key_method(
     SSL_CTX *ctx, const SSL_PRIVATE_KEY_METHOD *key_method);
 
 
+/* TLS ext CACHED_INFO (RFC 7924) */
+
+enum tlsext_cachedinfo_type_t {
+  tlsext_cachedinfo_type_cert,
+  tlsext_cachedinfo_type_cert_req,
+};
+
+/* Used by the client for caching server certificates */
+typedef struct client_cached_info_st {
+  enum tlsext_cachedinfo_type_t type;
+
+  /* |cached_info| stores the hash of a full TLS Certificate message */
+  uint8_t cached_info[TLSEXT_TLSCACHEDINFO_len];
+} CLIENT_CACHED_INFO;
+
+DECLARE_STACK_OF(CLIENT_CACHED_INFO)
+
+/* tlscachedinfo_find_certificate_cb_fn is a callback function that is called
+ * iwhen the ClientHello (for clients) is constructed when tls cached-info
+ * extension is enabled. This is not used by server.
+ *
+ * When called, it extracts a stack of CLIENT_CACHED_INFO from |cb_arg| and
+ * warites it to |cinfo_list|. It returns one on success and zero on failure.
+ */
+typedef int (*tlscachedinfo_get_list_cb_fn)(SSL *ssl,
+    STACK_OF(CLIENT_CACHED_INFO) **cinfo_list, void *cb_arg);
+
+/* tlscachedinfo_find_certificate_cb_fn is a callback function that is called
+ * when client is parsing ServerCertificate message, when tls cached-info
+ * extension is enabled. This is not used by server.
+ *
+ * When called, it matches |matching_cinfo| with the entries in |cached_infos|.
+ * It returns one on success and zero on failure. On success, it writes the
+ * constent of the TLS Certficate message corresponding to the |matching_cinfo|
+ * to |full_cert| and its size to |cert_len|.
+ */
+typedef int (*tlscachedinfo_find_certificate_cb_fn)(SSL *ssl,
+    const CLIENT_CACHED_INFO *matching_cinfo,
+    unsigned char **full_cert,
+    size_t *cert_len,
+    void *cb_arg);
+
+/* tlscachedinfo_new_certificate_cb_fn is a callback function that is called
+ * when client receives a new ServerCertificate message, if tls cached-info
+ * extension is enabled. This is not used by the server.
+ *
+ * When called, it updates the |cb_arg| to add the pair of the new server
+ * Certificate msg and its hash. It returns one on success and zero on failure.
+ */
+typedef int (*tlscachedinfo_new_certificate_cb_fn)(SSL *ssl,
+    const unsigned char *full_cert,
+    size_t cert_len, void *cb_arg);
+
+struct tlsext_cachedinfo_ctx_st {
+    uint8_t enabled;
+    tlscachedinfo_get_list_cb_fn get_list_cb;
+    tlscachedinfo_find_certificate_cb_fn find_certificate_cb;
+    tlscachedinfo_new_certificate_cb_fn new_certificate_cb;
+    void *cb_arg;
+};
+
+void SSL_CTX_set_cachedinfo_enabled(SSL_CTX *ctx,
+    uint8_t enabled);
+
+void SSL_CTX_set_cachedinfo_callbacks(SSL_CTX *ctx,
+    tlscachedinfo_get_list_cb_fn get_cert_cb,
+    tlscachedinfo_find_certificate_cb_fn find_cert_cb,
+    tlscachedinfo_new_certificate_cb_fn new_cert_cb,
+    void *cb_arg);
+
+void SSL_CTX_clear_cachedinfo_callbacks(SSL_CTX *ctx);
+
+
 /* Cipher suites.
  *
  * |SSL_CIPHER| objects represent cipher suites. */
@@ -4057,6 +4130,10 @@ struct ssl_ctx_st {
    * TODO(agl): remove once node.js no longer references this. */
   STACK_OF(X509)* extra_certs;
   int freelist_max_len;
+
+  /* tlsext_cachedinfo stores a set of callbacks when
+   * tls cached-info extension is enabled */
+  struct tlsext_cachedinfo_ctx_st *tlsext_cachedinfo;
 };
 
 typedef struct ssl_handshake_st SSL_HANDSHAKE;
@@ -4602,5 +4679,8 @@ BORINGSSL_MAKE_DELETER(SSL_SESSION, SSL_SESSION_free)
 #define SSL_R_TLSV1_BAD_CERTIFICATE_HASH_VALUE 1114
 #define SSL_R_TLSV1_UNKNOWN_PSK_IDENTITY 1115
 #define SSL_R_TLSV1_CERTIFICATE_REQUIRED 1116
+#define SSL_R_TLSCACHEDINFO_SEND_CERT 450
+#define SSL_R_TLSCACHEDINFO_RECV_CERT 451
+#define SSL_R_TLSCACHEDINFO_NEW_CERT 452
 
 #endif /* OPENSSL_HEADER_SSL_H */

--- a/include/openssl/stack_macros.h
+++ b/include/openssl/stack_macros.h
@@ -3985,3 +3985,93 @@
       CHECKED_CAST(void *(*)(void *), OPENSSL_STRING (*)(OPENSSL_STRING), \
                    copy_func),                                            \
       CHECKED_CAST(void (*)(void *), void (*)(OPENSSL_STRING), free_func)))
+
+/* CLIENT_CACHED_INFO (RFC7924- TLS Cached Information extension) */
+#define sk_CLIENT_CACHED_INFO_new(comp)                                    \
+  ((STACK_OF(CLIENT_CACHED_INFO) *)sk_new(CHECKED_CAST(                    \
+      stack_cmp_func,                                                      \
+      int (*)(const CLIENT_CACHED_INFO **a, const CLIENT_CACHED_INFO **b), \
+      comp)))
+
+#define sk_CLIENT_CACHED_INFO_new_null() \
+  ((STACK_OF(CLIENT_CACHED_INFO) *)sk_new_null())
+
+#define sk_CLIENT_CACHED_INFO_num(sk) \
+  sk_num(CHECKED_CAST(const _STACK *, const STACK_OF(CLIENT_CACHED_INFO) *, sk))
+
+#define sk_CLIENT_CACHED_INFO_zero(sk) \
+  sk_zero(CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk));
+
+#define sk_CLIENT_CACHED_INFO_value(sk, i)                                    \
+  ((CLIENT_CACHED_INFO *)sk_value(                                            \
+      CHECKED_CAST(const _STACK *, const STACK_OF(CLIENT_CACHED_INFO) *, sk), \
+      (i)))
+
+#define sk_CLIENT_CACHED_INFO_set(sk, i, p)                            \
+  ((CLIENT_CACHED_INFO *)sk_set(                                       \
+      CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk), (i), \
+      CHECKED_CAST(void *, CLIENT_CACHED_INFO *, p)))
+
+#define sk_CLIENT_CACHED_INFO_free(sk) \
+  sk_free(CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk))
+
+#define sk_CLIENT_CACHED_INFO_pop_free(sk, free_func)                        \
+  sk_pop_free(CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk),    \
+              CHECKED_CAST(void (*)(void *), void (*)(CLIENT_CACHED_INFO *), \
+                           free_func))
+
+#define sk_CLIENT_CACHED_INFO_insert(sk, p, where)                      \
+  sk_insert(CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk), \
+            CHECKED_CAST(void *, CLIENT_CACHED_INFO *, p), (where))
+
+#define sk_CLIENT_CACHED_INFO_delete(sk, where) \
+  ((CLIENT_CACHED_INFO *)sk_delete(             \
+      CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk), (where)))
+
+#define sk_CLIENT_CACHED_INFO_delete_ptr(sk, p)                   \
+  ((CLIENT_CACHED_INFO *)sk_delete_ptr(                           \
+      CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk), \
+      CHECKED_CAST(void *, CLIENT_CACHED_INFO *, p)))
+
+#define sk_CLIENT_CACHED_INFO_find(sk, out_index, p)                  \
+  sk_find(CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk), \
+          (out_index), CHECKED_CAST(void *, CLIENT_CACHED_INFO *, p))
+
+#define sk_CLIENT_CACHED_INFO_shift(sk) \
+  ((CLIENT_CACHED_INFO *)sk_shift(      \
+      CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk)))
+
+#define sk_CLIENT_CACHED_INFO_push(sk, p)                             \
+  sk_push(CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk), \
+          CHECKED_CAST(void *, CLIENT_CACHED_INFO *, p))
+
+#define sk_CLIENT_CACHED_INFO_pop(sk) \
+  ((CLIENT_CACHED_INFO *)sk_pop(      \
+      CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk)))
+
+#define sk_CLIENT_CACHED_INFO_dup(sk)      \
+  ((STACK_OF(CLIENT_CACHED_INFO) *)sk_dup( \
+      CHECKED_CAST(const _STACK *, const STACK_OF(CLIENT_CACHED_INFO) *, sk)))
+
+#define sk_CLIENT_CACHED_INFO_sort(sk) \
+  sk_sort(CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk))
+
+#define sk_CLIENT_CACHED_INFO_is_sorted(sk) \
+  sk_is_sorted(                             \
+      CHECKED_CAST(const _STACK *, const STACK_OF(CLIENT_CACHED_INFO) *, sk))
+
+#define sk_CLIENT_CACHED_INFO_set_cmp_func(sk, comp)                           \
+  ((int (*)(const CLIENT_CACHED_INFO **a, const CLIENT_CACHED_INFO **b))       \
+       sk_set_cmp_func(                                                        \
+           CHECKED_CAST(_STACK *, STACK_OF(CLIENT_CACHED_INFO) *, sk),         \
+           CHECKED_CAST(stack_cmp_func, int (*)(const CLIENT_CACHED_INFO **a,  \
+                                                const CLIENT_CACHED_INFO **b), \
+                        comp)))
+
+#define sk_CLIENT_CACHED_INFO_deep_copy(sk, copy_func, free_func)             \
+  ((STACK_OF(CLIENT_CACHED_INFO) *)sk_deep_copy(                              \
+      CHECKED_CAST(const _STACK *, const STACK_OF(CLIENT_CACHED_INFO) *, sk), \
+      CHECKED_CAST(void *(*)(void *),                                         \
+                   CLIENT_CACHED_INFO *(*)(CLIENT_CACHED_INFO *), copy_func), \
+      CHECKED_CAST(void (*)(void *), void (*)(CLIENT_CACHED_INFO *),          \
+                   free_func)))

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -229,6 +229,11 @@ extern "C" {
 /* This is not an IANA defined extension number */
 #define TLSEXT_TYPE_short_header 27463
 
+/* ExtensionType value from RFC7924 */
+#define TLSEXT_TYPE_tlscachedinfo 25
+
+#define TLSEXT_TLSCACHEDINFO_len 32
+
 /* status request value from RFC 3546 */
 #define TLSEXT_STATUSTYPE_ocsp 1
 

--- a/ssl/handshake_client.c
+++ b/ssl/handshake_client.c
@@ -4,21 +4,21 @@
  * This package is an SSL implementation written
  * by Eric Young (eay@cryptsoft.com).
  * The implementation was written so as to conform with Netscapes SSL.
- * 
+ *
  * This library is free for commercial and non-commercial use as long as
  * the following conditions are aheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
  * except that the holder is Tim Hudson (tjh@cryptsoft.com).
- * 
+ *
  * Copyright remains Eric Young's, and as such any Copyright notices in
  * the code are not to be removed.
  * If this package is used in a product, Eric Young should be given attribution
  * as the author of the parts of the library used.
  * This can be in the form of a textual message at program startup or
  * in documentation (online or textual) provided with the package.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -33,10 +33,10 @@
  *     Eric Young (eay@cryptsoft.com)"
  *    The word 'cryptographic' can be left out if the rouines from the library
  *    being used are not cryptographic related :-).
- * 4. If you include any Windows specific code (or a derivative thereof) from 
+ * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
  *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -48,7 +48,7 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- * 
+ *
  * The licence and distribution terms for any publically available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
@@ -62,7 +62,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -110,7 +110,7 @@
 /* ====================================================================
  * Copyright 2002 Sun Microsystems, Inc. ALL RIGHTS RESERVED.
  *
- * Portions of the attached software ("Contribution") are developed by 
+ * Portions of the attached software ("Contribution") are developed by
  * SUN MICROSYSTEMS, INC., and are contributed to the OpenSSL project.
  *
  * The Contribution is licensed pursuant to the OpenSSL open source
@@ -1032,6 +1032,46 @@ err:
   return -1;
 }
 
+int ssl3_parse_cert_chain_hash(SSL *ssl, CBS *cbs, uint8_t *received_new_cert) {
+  *received_new_cert = 1;
+  if (!ssl_is_cachedinfo_enabled(ssl) ||
+      ssl->init_num != TLSEXT_TLSCACHEDINFO_len ||
+      !ssl->s3->cached_info_sent ||
+      !ssl->s3->cached_info_supported_by_server ||
+      ssl->ctx->tlsext_cachedinfo->find_certificate_cb == NULL) {
+    return 1;
+  }
+
+  // the cert message contains hash of cert chain
+  CLIENT_CACHED_INFO cinfo;
+  cinfo.type = tlsext_cachedinfo_type_cert;
+  if (!CBS_copy_bytes(cbs, cinfo.cached_info, TLSEXT_TLSCACHEDINFO_len)) {
+    return 0;
+  }
+  size_t new_len = 0;
+  unsigned char *new_data = NULL;
+  if (ssl->ctx->tlsext_cachedinfo->find_certificate_cb(
+        ssl,
+        &cinfo,
+        &new_data,
+        &new_len,
+        ssl->ctx->tlsext_cachedinfo->cb_arg) <= 0) {
+    SSLerr(SSL_F_SSL3_GET_SERVER_CERTIFICATE,
+        SSL_R_TLSCACHEDINFO_RECV_CERT);
+    return 0;
+  }
+
+  if (new_len > 0 && new_data) {
+    *received_new_cert = 0;
+    CBS_init(cbs,
+             (uint8_t *) new_data + SSL3_HM_HEADER_LENGTH,
+             new_len - SSL3_HM_HEADER_LENGTH);
+  } else {
+    CBS_init(cbs, ssl->init_msg, ssl->init_num);
+  }
+  return 1;
+}
+
 static int ssl3_get_server_certificate(SSL_HANDSHAKE *hs) {
   SSL *const ssl = hs->ssl;
   int ret =
@@ -1042,6 +1082,10 @@ static int ssl3_get_server_certificate(SSL_HANDSHAKE *hs) {
 
   CBS cbs;
   CBS_init(&cbs, ssl->init_msg, ssl->init_num);
+  uint8_t received_new_cert = 1;
+  if (!ssl3_parse_cert_chain_hash(ssl, &cbs, &received_new_cert)) {
+    return 0;
+  }
 
   uint8_t alert;
   sk_CRYPTO_BUFFER_pop_free(ssl->s3->new_session->certs, CRYPTO_BUFFER_free);
@@ -1067,6 +1111,19 @@ static int ssl3_get_server_certificate(SSL_HANDSHAKE *hs) {
           sk_CRYPTO_BUFFER_value(ssl->s3->new_session->certs, 0))) {
     ssl3_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_ILLEGAL_PARAMETER);
     return -1;
+  }
+
+  if (ssl_is_cachedinfo_enabled(ssl) &&
+      received_new_cert &&
+      ssl->ctx->tlsext_cachedinfo->new_certificate_cb != NULL) {
+    if (ssl->ctx->tlsext_cachedinfo->new_certificate_cb(
+          ssl,
+          (const unsigned char*)ssl->init_buf->data,
+          ssl->init_num + SSL3_HM_HEADER_LENGTH,
+          ssl->ctx->tlsext_cachedinfo->cb_arg) <= 0) {
+      SSLerr(SSL_F_SSL3_GET_SERVER_CERTIFICATE,
+          SSL_R_TLSCACHEDINFO_RECV_CERT);
+    }
   }
 
   return 1;

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -809,6 +809,26 @@ int ssl_check_leaf_certificate(SSL *ssl, EVP_PKEY *pkey,
                                const CRYPTO_BUFFER *leaf);
 
 
+/* CACHED_INFO */
+
+int ssl_is_cachedinfo_enabled(SSL *ssl);
+
+/* ssl_cert_matched_cachedinfo returns one if |cert_chain_hash| macthes one of
+ * the hashes in |cached_infos|, zero otherwise. */
+int ssl_cert_matched_cachedinfo(SSL *ssl);
+
+/* If |cert_chain_hash| matches one of the hashes in |cached_infos|, it adds
+ * |cert_chain_hash| to |cbb| in the format used by a TLS Certificate message.
+ * Otherwise, calls ssl_add_cert_chain. It returns one on success and zero on
+ * failure to add neither |cert_chain_hash| nor cert chain.*/
+int ssl_add_cert_chain_or_hash(SSL *ssl, CBB *cbb);
+
+/* ssl_gen_cert_chain_hash generates a SHA256 hash of a complete TLS Certificate
+ * message and stores it in |cert_chain_hash|.
+ * It returns one on success and zero on failure. */
+int ssl_gen_cert_chain_hash(SSL *ssl);
+
+
 /* TLS 1.3 key derivation. */
 
 /* tls13_init_key_schedule initializes the handshake hash and key derivation
@@ -1269,6 +1289,10 @@ typedef struct cert_st {
   /* Optional X509_STORE for certificate validation. If NULL the parent SSL_CTX
    * store is used instead. */
   X509_STORE *verify_store;
+
+  /* cert_chain_hash, if non-NULL, stores a SHA256 hash of the full server
+   * Certficate message */
+  uint8_t *cert_chain_hash;
 } CERT;
 
 /* SSL_METHOD is a compatibility structure to support the legacy version-locked
@@ -1577,6 +1601,14 @@ typedef struct ssl3_state_st {
    *     verified Channel ID from the client: a P256 point, (x,y), where
    *     each are big-endian values. */
   uint8_t tlsext_channel_id[64];
+
+  /* Only used for client-side bookkeeping */
+  unsigned cached_info_sent:1;
+  unsigned cached_info_supported_by_server:1;
+  /* Only used on the server-side, to store the cached infos
+   * sent in the ClientHello until the Certificate message is created
+   */
+  STACK_OF(CLIENT_CACHED_INFO) *cached_infos;
 } SSL3_STATE;
 
 /* lengths of messages */
@@ -1770,6 +1802,8 @@ int ssl3_new(SSL *ssl);
 void ssl3_free(SSL *ssl);
 int ssl3_accept(SSL_HANDSHAKE *hs);
 int ssl3_connect(SSL_HANDSHAKE *hs);
+
+int ssl3_parse_cert_chain_hash(SSL *ssl, CBS *cbs, uint8_t *received_new_cert);
 
 int ssl3_init_message(SSL *ssl, CBB *cbb, CBB *body, uint8_t type);
 int ssl3_finish_message(SSL *ssl, CBB *cbb, uint8_t **out_msg, size_t *out_len);

--- a/ssl/s3_both.c
+++ b/ssl/s3_both.c
@@ -375,7 +375,7 @@ int ssl3_send_change_cipher_spec(SSL *ssl) {
 int ssl3_output_cert_chain(SSL *ssl) {
   CBB cbb, body;
   if (!ssl->method->init_message(ssl, &cbb, &body, SSL3_MT_CERTIFICATE) ||
-      !ssl_add_cert_chain(ssl, &body) ||
+      !ssl_add_cert_chain_or_hash(ssl, &body) ||
       !ssl_complete_message(ssl, &cbb)) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
     CBB_cleanup(&cbb);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -210,6 +210,8 @@ void ssl3_free(SSL *ssl) {
   SSL_AEAD_CTX_free(ssl->s3->aead_read_ctx);
   SSL_AEAD_CTX_free(ssl->s3->aead_write_ctx);
   OPENSSL_free(ssl->s3->pending_message);
+  sk_CLIENT_CACHED_INFO_pop_free(ssl->s3->cached_infos,
+                                 (void (*) (CLIENT_CACHED_INFO*))CRYPTO_free);
 
   OPENSSL_cleanse(ssl->s3, sizeof *ssl->s3);
   OPENSSL_free(ssl->s3);

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -229,6 +229,10 @@ void ssl_cert_clear_certs(CERT *cert) {
   sk_X509_pop_free(cert->x509_chain, X509_free);
   cert->x509_chain = NULL;
   cert->key_method = NULL;
+  if (cert->cert_chain_hash != NULL) {
+    OPENSSL_free(cert->cert_chain_hash);
+  }
+  cert->cert_chain_hash = NULL;
 }
 
 void ssl_cert_free(CERT *c) {
@@ -605,6 +609,59 @@ int ssl_add_cert_chain(SSL *ssl, CBB *cbb) {
   }
 
   return CBB_flush(cbb);
+}
+
+int ssl_gen_cert_chain_hash(SSL *ssl) {
+  CERT *cert = ssl->cert;
+  if (cert == NULL) {
+    return 0;
+  }
+  CBB cbb, body;
+  CBB_zero(&cbb);
+  if (!CBB_init(&cbb, 64) ||
+      !CBB_add_u8(&cbb, SSL3_MT_CERTIFICATE) ||
+      !CBB_add_u24_length_prefixed(&cbb, &body) ||
+      !ssl_add_cert_chain(ssl, &body)) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
+    CBB_cleanup(&cbb);
+    return 0;
+  }
+  uint8_t *msg = NULL;
+  size_t len;
+  if (!CBB_finish(&cbb, &msg, &len) ||
+      len > 0xffffffffu) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
+    CBB_cleanup(&cbb);
+    OPENSSL_free(msg);
+    return 0;
+  }
+  if (len > TLSEXT_TLSCACHEDINFO_len) {
+    uint8_t *cert_sha2 = (uint8_t *)OPENSSL_malloc(TLSEXT_TLSCACHEDINFO_len);
+    SHA256((const uint8_t *)msg, len, cert_sha2);
+    cert->cert_chain_hash = cert_sha2;
+  }
+
+  CBB_cleanup(&cbb);
+  OPENSSL_free(msg);
+
+  return (cert->cert_chain_hash != NULL);
+}
+
+int ssl_add_cert_chain_or_hash(SSL *ssl, CBB *cbb) {
+  if (!ssl_cert_matched_cachedinfo(ssl)) {
+    return ssl_add_cert_chain(ssl, cbb);
+  }
+
+  uint8_t *buf;
+  if (!CBB_add_space(cbb, &buf, TLSEXT_TLSCACHEDINFO_len)) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_MALLOC_FAILURE);
+    return 0;
+  }
+  if (buf == NULL) {
+    return 0;
+  }
+  memcpy(buf, ssl->cert->cert_chain_hash, TLSEXT_TLSCACHEDINFO_len);
+  return 1;
 }
 
 /* ssl_cert_skip_to_spki parses a DER-encoded, X.509 certificate from |in| and

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4,21 +4,21 @@
  * This package is an SSL implementation written
  * by Eric Young (eay@cryptsoft.com).
  * The implementation was written so as to conform with Netscapes SSL.
- * 
+ *
  * This library is free for commercial and non-commercial use as long as
  * the following conditions are aheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
  * except that the holder is Tim Hudson (tjh@cryptsoft.com).
- * 
+ *
  * Copyright remains Eric Young's, and as such any Copyright notices in
  * the code are not to be removed.
  * If this package is used in a product, Eric Young should be given attribution
  * as the author of the parts of the library used.
  * This can be in the form of a textual message at program startup or
  * in documentation (online or textual) provided with the package.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -33,10 +33,10 @@
  *     Eric Young (eay@cryptsoft.com)"
  *    The word 'cryptographic' can be left out if the rouines from the library
  *    being used are not cryptographic related :-).
- * 4. If you include any Windows specific code (or a derivative thereof) from 
+ * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
  *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -48,7 +48,7 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- * 
+ *
  * The licence and distribution terms for any publically available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
@@ -62,7 +62,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -109,7 +109,7 @@
  */
 /* ====================================================================
  * Copyright 2002 Sun Microsystems, Inc. ALL RIGHTS RESERVED.
- * ECC cipher suite support in OpenSSL originally developed by 
+ * ECC cipher suite support in OpenSSL originally developed by
  * SUN MICROSYSTEMS, INC., and contributed to the OpenSSL project.
  */
 /* ====================================================================
@@ -304,6 +304,13 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *method) {
     ret->options |= SSL_OP_NO_TICKET;
   }
 
+  ret->tlsext_cachedinfo = (struct tlsext_cachedinfo_ctx_st *) OPENSSL_malloc(sizeof(struct tlsext_cachedinfo_ctx_st));
+  ret->tlsext_cachedinfo->enabled = 0;
+  ret->tlsext_cachedinfo->get_list_cb = NULL;
+  ret->tlsext_cachedinfo->find_certificate_cb = NULL;
+  ret->tlsext_cachedinfo->new_certificate_cb = NULL;
+  ret->tlsext_cachedinfo->cb_arg = NULL;
+
   /* Disable the auto-chaining feature by default. Once this has stuck without
    * problems, the feature will be removed entirely. */
   ret->mode = SSL_MODE_NO_AUTO_CHAIN;
@@ -365,6 +372,8 @@ void SSL_CTX_free(SSL_CTX *ctx) {
   CRYPTO_BUFFER_free(ctx->ocsp_response);
   OPENSSL_free(ctx->signed_cert_timestamp_list);
   EVP_PKEY_free(ctx->tlsext_channel_id_private);
+  OPENSSL_free(ctx->tlsext_cachedinfo);
+  ctx->tlsext_cachedinfo = NULL;
 
   OPENSSL_free(ctx);
 }
@@ -3037,4 +3046,56 @@ int SSL_set_min_version(SSL *ssl, uint16_t version) {
 
 int SSL_set_max_version(SSL *ssl, uint16_t version) {
   return SSL_set_max_proto_version(ssl, version);
+}
+
+void SSL_CTX_set_cachedinfo_enabled(SSL_CTX *ctx, uint8_t enabled) {
+  ctx->tlsext_cachedinfo->enabled = enabled;
+}
+
+void SSL_CTX_set_cachedinfo_callbacks(SSL_CTX *ctx,
+    tlscachedinfo_get_list_cb_fn get_cert_cb,
+    tlscachedinfo_find_certificate_cb_fn find_cert_cb,
+    tlscachedinfo_new_certificate_cb_fn new_cert_cb,
+    void* cb_arg) {
+  SSL_CTX_set_cachedinfo_enabled(ctx, 1);
+  ctx->tlsext_cachedinfo->get_list_cb = get_cert_cb;
+  ctx->tlsext_cachedinfo->find_certificate_cb = find_cert_cb;
+  ctx->tlsext_cachedinfo->new_certificate_cb = new_cert_cb;
+  ctx->tlsext_cachedinfo->cb_arg = cb_arg;
+}
+
+void SSL_CTX_clear_cachedinfo_callbacks(SSL_CTX *ctx) {
+  SSL_CTX_set_cachedinfo_enabled(ctx, 0);
+  ctx->tlsext_cachedinfo->get_list_cb = NULL;
+  ctx->tlsext_cachedinfo->find_certificate_cb = NULL;
+  ctx->tlsext_cachedinfo->new_certificate_cb = NULL;
+  ctx->tlsext_cachedinfo->cb_arg = NULL;
+}
+
+int ssl_is_cachedinfo_enabled(SSL *ssl) {
+  return (ssl->ctx &&
+          ssl->ctx->tlsext_cachedinfo->enabled != 0);
+}
+
+int ssl_cert_matched_cachedinfo(SSL *ssl) {
+  CERT *cert = ssl->cert;
+  if (cert == NULL ||
+      !ssl_is_cachedinfo_enabled(ssl) ||
+      ssl->s3->cached_infos == NULL ||
+      sk_CLIENT_CACHED_INFO_num(ssl->s3->cached_infos) <= 0 ||
+      cert->cert_chain_hash == NULL) {
+    return 0;
+  }
+  uint8_t *hash = cert->cert_chain_hash;
+  size_t cachedinfo_count = sk_CLIENT_CACHED_INFO_num(ssl->s3->cached_infos);
+
+  for (size_t i = 0; i < cachedinfo_count; ++i) {
+    CLIENT_CACHED_INFO *cinfo =
+      sk_CLIENT_CACHED_INFO_value(ssl->s3->cached_infos, i);
+    if (cinfo->type == tlsext_cachedinfo_type_cert &&
+        memcmp(cinfo->cached_info, hash, TLSEXT_TLSCACHEDINFO_len) == 0) {
+      return 1;
+    }
+  }
+  return 0;
 }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -4,21 +4,21 @@
  * This package is an SSL implementation written
  * by Eric Young (eay@cryptsoft.com).
  * The implementation was written so as to conform with Netscapes SSL.
- * 
+ *
  * This library is free for commercial and non-commercial use as long as
  * the following conditions are aheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
  * except that the holder is Tim Hudson (tjh@cryptsoft.com).
- * 
+ *
  * Copyright remains Eric Young's, and as such any Copyright notices in
  * the code are not to be removed.
  * If this package is used in a product, Eric Young should be given attribution
  * as the author of the parts of the library used.
  * This can be in the form of a textual message at program startup or
  * in documentation (online or textual) provided with the package.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -33,10 +33,10 @@
  *     Eric Young (eay@cryptsoft.com)"
  *    The word 'cryptographic' can be left out if the rouines from the library
  *    being used are not cryptographic related :-).
- * 4. If you include any Windows specific code (or a derivative thereof) from 
+ * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
  *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -48,7 +48,7 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- * 
+ *
  * The licence and distribution terms for any publically available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
@@ -62,7 +62,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -730,6 +730,138 @@ static int ext_sni_add_serverhello(SSL_HANDSHAKE *hs, CBB *out) {
     return 0;
   }
 
+  return 1;
+}
+
+
+/* CACHED_INFO */
+
+static int ext_ci_add_clienthello(SSL_HANDSHAKE *hs, CBB *out) {
+  SSL *ssl = hs->ssl;
+  if (!ssl_is_cachedinfo_enabled(ssl)) {
+    return 1;
+  }
+  STACK_OF(CLIENT_CACHED_INFO) *cinfos = NULL;
+  if (ssl->ctx->tlsext_cachedinfo->get_list_cb == NULL ||
+      ssl->ctx->tlsext_cachedinfo->get_list_cb(
+        ssl, &cinfos, ssl->ctx->tlsext_cachedinfo->cb_arg) <= 0 ||
+      cinfos == NULL ||
+      sk_CLIENT_CACHED_INFO_num(cinfos) == 0) {
+    return 1;
+  }
+
+  CBB contents;
+  if (!CBB_add_u16(out, TLSEXT_TYPE_tlscachedinfo) ||
+      !CBB_add_u16_length_prefixed(out, &contents)) {
+    return 0;
+  }
+
+  for (size_t i = 0; i < sk_CLIENT_CACHED_INFO_num(cinfos); ++i) {
+    CLIENT_CACHED_INFO *cinfo = sk_CLIENT_CACHED_INFO_value(cinfos, i);
+    if (!CBB_add_u8(&contents, cinfo->type)) {
+      return 0;
+    }
+    for (int j = 0; j < TLSEXT_TLSCACHEDINFO_len; ++j) {
+      if (!CBB_add_u8(&contents, cinfo->cached_info[j])) {
+        return 0;
+      }
+    }
+  }
+
+  if (!CBB_flush(out)) {
+    return 0;
+  }
+
+  ssl->s3->cached_info_sent = 1;
+  sk_CLIENT_CACHED_INFO_pop_free(cinfos,
+    (void (*) (CLIENT_CACHED_INFO*))CRYPTO_free);
+  return 1;
+}
+
+static int ext_ci_parse_serverhello(SSL_HANDSHAKE *hs, uint8_t *out_alert,
+                                    CBS *contents) {
+  if (contents == NULL) {
+    return 1;
+  }
+
+  if (!ssl_is_cachedinfo_enabled(hs->ssl)) {
+    return 1;
+  }
+
+  uint8_t type;
+  if (!CBS_get_u8(contents, &type)) {
+    return 0;
+  }
+
+  switch (type) {
+    case tlsext_cachedinfo_type_cert:
+      hs->ssl->s3->cached_info_supported_by_server = 1;
+      break;
+    case tlsext_cachedinfo_type_cert_req:
+      /* not supported */
+      break;
+    default:
+      *out_alert = SSL_AD_ILLEGAL_PARAMETER;
+      return 0;
+  }
+  return 1;
+}
+
+static int ext_ci_parse_clienthello(SSL_HANDSHAKE *hs, uint8_t *out_alert,
+                                    CBS *contents) {
+  if (contents == NULL) {
+    return 1;
+  }
+  if (!ssl_is_cachedinfo_enabled(hs->ssl)) {
+    return 1;
+  }
+
+  hs->ssl->s3->cached_infos = sk_CLIENT_CACHED_INFO_new_null();
+  uint8_t type;
+  while (CBS_get_u8(contents, &type)) {
+    switch (type) {
+      case tlsext_cachedinfo_type_cert:
+      {
+        CLIENT_CACHED_INFO *cached_info =
+          OPENSSL_malloc(sizeof(CLIENT_CACHED_INFO));
+        cached_info->type = type;
+        if (!CBS_copy_bytes(
+              contents, cached_info->cached_info, TLSEXT_TLSCACHEDINFO_len)) {
+          return 0;
+        }
+        sk_CLIENT_CACHED_INFO_push(hs->ssl->s3->cached_infos, cached_info);
+        break;
+      }
+      case tlsext_cachedinfo_type_cert_req:
+        /* not implemented, skip */
+        break;
+      default:
+        *out_alert = SSL_AD_ILLEGAL_PARAMETER;
+        return 0;
+    }
+  }
+
+  if (CBS_len(contents) != 0) {
+    return 0;
+  }
+  return 1;
+}
+
+static int ext_ci_add_serverhello(SSL_HANDSHAKE *hs, CBB *out) {
+  SSL *ssl = hs->ssl;
+  if (!ssl_is_cachedinfo_enabled(ssl) ||
+      !ssl_gen_cert_chain_hash(ssl) ||
+      !ssl_cert_matched_cachedinfo(ssl)) {
+    return 1;
+  }
+
+  CBB content;
+  if (!CBB_add_u16(out, TLSEXT_TYPE_tlscachedinfo) ||
+      !CBB_add_u16_length_prefixed(out, &content) ||
+      !CBB_add_u8(&content, tlsext_cachedinfo_type_cert) ||
+      !CBB_flush(out)) {
+    return 0;
+  }
   return 1;
 }
 
@@ -2727,6 +2859,14 @@ static const struct tls_extension kExtensions[] = {
     forbid_parse_serverhello,
     ignore_parse_clienthello,
     dont_add_serverhello,
+  },
+  {
+    TLSEXT_TYPE_tlscachedinfo,
+    NULL,
+    ext_ci_add_clienthello,
+    ext_ci_parse_serverhello,
+    ext_ci_parse_clienthello,
+    ext_ci_add_serverhello,
   },
   {
     TLSEXT_TYPE_short_header,

--- a/tool/client.cc
+++ b/tool/client.cc
@@ -104,6 +104,14 @@ static const struct argument kArguments[] = {
       "Establish a second connection resuming the original connection.",
     },
     {
+      "-tlscachedinfo_in", kOptionalArgument,
+      "Read cached info (certs) from file (needs -servername)",
+    },
+    {
+      "-tlscachedinfo_out", kOptionalArgument,
+      "Write cached cert to file (needs -servername)",
+    },
+    {
      "", kOptionalArgument, "",
     },
 };
@@ -391,6 +399,28 @@ bool Client(const std::vector<std::string> &args) {
   if (args_map.count("-resume") != 0 &&
       !DoConnection(ctx.get(), args_map, &WaitForSession)) {
     return false;
+  }
+
+  if (args_map.count("-tlscachedinfo_in") != 0) {
+    const char *in_file = args_map["-tlscachedinfo_in"].c_str();
+    struct s_client_cachedinfo_ctx* cachedinfo_ctx =
+      (struct s_client_cachedinfo_ctx*)
+      OPENSSL_malloc( sizeof( struct s_client_cachedinfo_ctx));
+    memset(cachedinfo_ctx, 0, sizeof( struct s_client_cachedinfo_ctx));
+
+    cachedinfo_ctx->certlen = cachedinfo_parse_cert_file(in_file,
+        cachedinfo_ctx->cert, sizeof( cachedinfo_ctx->cert));
+    const char *out_file;
+    if (args_map.count("-tlscachedinfo_out") != 0) {
+      out_file = args_map["-tlscachedinfo_out"].c_str();
+    } else {
+      out_file = in_file;
+    }
+    memcpy(cachedinfo_ctx->out_filename, out_file, strlen(out_file));
+    SSL_CTX_set_cachedinfo_callbacks(ctx.get(), get_list_cb_fn,
+                                     find_certificate_cb_fn,
+                                     new_certificate_cb_fn,
+                                     (void*) cachedinfo_ctx);
   }
 
   return DoConnection(ctx.get(), args_map, &TransferData);

--- a/tool/server.cc
+++ b/tool/server.cc
@@ -54,6 +54,10 @@ static const struct argument kArguments[] = {
         "The server will continue accepting new sequential connections.",
     },
     {
+        "-tlscachedinfo", kBooleanArgument,
+        "Support TLS cached info requests from clients",
+    },
+    {
         "", kOptionalArgument, "",
     },
 };
@@ -155,6 +159,10 @@ bool Server(const std::vector<std::string> &args) {
 
   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
   SSL_CTX_set_options(ctx.get(), SSL_OP_NO_SSLv3);
+
+  if (args_map.count("-tlscachedinfo") != 0) {
+    SSL_CTX_set_cachedinfo_enabled(ctx.get(), 1);
+  }
 
   // Server authentication is required.
   if (args_map.count("-key") != 0) {

--- a/tool/transport_common.cc
+++ b/tool/transport_common.cc
@@ -602,3 +602,103 @@ bool DoSMTPStartTLS(int sock) {
 
   return true;
 }
+
+int cachedinfo_parse_cert_file(const char *filename,
+                               uint8_t *buf, size_t buflen) {
+  unsigned int read = 0;
+  BIO *certbio = BIO_new_file(filename, "r");
+  if (!certbio) {
+    fprintf(stderr, "Can't open cached info file %s\n", filename);
+    return 0;
+  }
+
+  if ((read = BIO_read(certbio, buf, buflen)) <= 0) {
+    BIO_printf(certbio, "Unable to read data from %s\n", filename);
+    read = 0;
+  }
+
+  BIO_free(certbio);
+  return read;
+}
+
+int cachedinfo_store_cert_to_file(const char *filename,
+                                  const uint8_t *buf, size_t buflen) {
+  size_t written;
+  int rc = 1;
+  BIO *bio = BIO_new_file(filename, "w");
+  if (!bio) {
+    fprintf(stderr, "Cannot open file %s\n", filename);
+    return 0;
+  }
+
+  written = BIO_write(bio, buf, buflen);
+  if (written != buflen) {
+    BIO_printf(bio, "Error: wrote %zu bytes (asked for %u) to file %s\n",
+        written, (uint16_t) buflen, filename);
+    rc = 0;
+  }
+  BIO_free(bio);
+  return rc;
+}
+
+int get_list_cb_fn(SSL *ssl, STACK_OF(CLIENT_CACHED_INFO) * *cinfo_list,
+                   void *cb_arg) {
+  struct s_client_cachedinfo_ctx *st = (struct s_client_cachedinfo_ctx*) cb_arg;
+  if (st == NULL) {
+    fprintf(stderr, "ctx empty");
+    return 0;
+  }
+
+  if (st->certlen > 0) {
+    SHA256(st->cert, st->certlen, st->certdigest);
+    st->valid = 1;
+
+    *cinfo_list = sk_CLIENT_CACHED_INFO_new_null();
+    CLIENT_CACHED_INFO *info =
+        (CLIENT_CACHED_INFO *)OPENSSL_malloc(sizeof(CLIENT_CACHED_INFO));
+    info->type = tlsext_cachedinfo_type_cert;
+    memcpy(info->cached_info, st->certdigest, SHA256_DIGEST_LENGTH);
+    sk_CLIENT_CACHED_INFO_push(*cinfo_list, info);
+    st->sent = 1;
+    return 1;
+  } else {
+    *cinfo_list = NULL;
+  }
+  return 0;
+}
+
+
+int find_certificate_cb_fn(SSL *ssl, const CLIENT_CACHED_INFO *matching_cinfo,
+                           uint8_t **full_cert, size_t *cert_len,
+                           void *cb_arg) {
+  struct s_client_cachedinfo_ctx *st = (struct s_client_cachedinfo_ctx*) cb_arg;
+
+  if (st == NULL || !st->valid || !st->sent) {
+    return 0;
+  }
+
+  if (!memcmp(matching_cinfo->cached_info, st->certdigest,
+              SHA256_DIGEST_LENGTH)) {
+    *full_cert = (uint8_t *) OPENSSL_malloc(st->certlen);
+    memcpy(*full_cert, st->cert, st->certlen);
+    *cert_len = st->certlen;
+    return 1;
+
+  }
+  return 0;
+}
+
+int new_certificate_cb_fn(SSL *ssl, const uint8_t *full_cert,
+                          size_t cert_len, void *cb_arg) {
+  struct s_client_cachedinfo_ctx *st = (struct s_client_cachedinfo_ctx*) cb_arg;
+
+  if (st == NULL) {
+    return 0;
+  }
+
+  if (st->out_filename) {
+    /* We don't care about the return code */
+    cachedinfo_store_cert_to_file(st->out_filename, full_cert, cert_len);
+  }
+  return 1;
+}

--- a/tool/transport_common.h
+++ b/tool/transport_common.h
@@ -45,4 +45,29 @@ bool TransferData(SSL *ssl, int sock);
 // returns true on success and false otherwise.
 bool DoSMTPStartTLS(int sock);
 
+extern int cinfo_ex_index;
+struct s_client_cachedinfo_ctx {
+  char out_filename[256];
+  uint8_t cert[8192];
+  size_t certlen;
+  uint8_t certdigest[SHA256_DIGEST_LENGTH];
+  uint8_t valid;
+  uint8_t sent;
+};
+
+extern int tlscinfo_ex_index;
+typedef struct client_cached_info_st CLIENT_CACHED_INFO;
+
+int get_list_cb_fn(SSL *ssl, STACK_OF(CLIENT_CACHED_INFO) * *cinfo_list,
+                   void *cb_arg);
+int find_certificate_cb_fn(SSL *ssl, const CLIENT_CACHED_INFO *matching_cinfo,
+                           uint8_t **full_cert, size_t *cert_len,
+                           void *cb_arg);
+int new_certificate_cb_fn(SSL *ssl, const uint8_t *full_cert,
+                          size_t cert_len, void *cb_arg);
+int cachedinfo_parse_cert_file(const char *filename, uint8_t *buf,
+                               size_t buflen);
+int cachedinfo_store_cert_to_file(const char *filename, const uint8_t *buf,
+                                  size_t buflen);
+
 #endif  /* !OPENSSL_HEADER_TOOL_TRANSPORT_COMMON_H */


### PR DESCRIPTION
Summary: ^^

Test Plan:
./tool/bssl s_server -key /home/rnandan/ec_certs/ca.combined -accept 4443 -tlscachedinfo
./tool/bssl s_client -connect localhost:4443 -server-name dev12117.prn1.facebook.com -tlscachedinfo_in infoout -tlscachedinfo_out infoout2



Please do not send pull requests to the BoringSSL repository.

We do, however, take contributions gladly.

See https://boringssl.googlesource.com/boringssl/+/master/CONTRIBUTING.md

Thanks!
