### PR TITLE
fix[build shared bug]: shared build fails on Mac OS X as ssl needs li…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,8 @@ add_executable(
   src/tool/transport_common.cc
 )
 
+target_link_libraries(ssl crypto)
+
 target_link_libraries(bssl ssl crypto)
 
 if(NOT WIN32 AND NOT ANDROID)


### PR DESCRIPTION
…bcrypto symbols hence needs to depend from libcrypto.

Please do not send pull requests to the BoringSSL repository.

We do, however, take contributions gladly.

See https://boringssl.googlesource.com/boringssl/+/master/CONTRIBUTING.md

Thanks!
