### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -121,6 +121,18 @@ architecture of the host machine, e.g. `linux-x86_64`.
     ${ANDROID_NDK}/prebuilt/HOST/bin/gdb
     target remote :5039  # in gdb
 
+###Build for vcpkg
+
+You can build and install boringssl using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install boringssl
+
+The boringssl port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Building for iOS
 
 To build for iOS, pass `-DCMAKE_OSX_SYSROOT=iphoneos` and


### PR DESCRIPTION
`boringssl` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `boringssl` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `boringssl`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/boringssl/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊