### PR TITLE
Return BoringSSL-FIPS when calling OpenSsl.versionString() for FIPS branch

### DIFF
--- a/crypto/crypto.c
+++ b/crypto/crypto.c
@@ -195,7 +195,7 @@ const char *SSLeay_version(int which) { return OpenSSL_version(which); }
 const char *OpenSSL_version(int which) {
   switch (which) {
     case OPENSSL_VERSION:
-      return "BoringSSL";
+      return "BoringSSL-FIPS";
     case OPENSSL_CFLAGS:
       return "compiler: n/a";
     case OPENSSL_BUILT_ON:


### PR DESCRIPTION
Summary:
- Currently calling `OpenSsl.versionString()` prints `BoringSSL` for FIPS branchs also. 
- This causes confusion at runtime "Are we using FIPS booringSSL or non FIPS one?"
- This makes validation difficult for Developers and External FedRAMP vendors.
- This PR adds suffix to OpenSsl.versionString() to print `BoringSSL-FIPS` to ease pain.