### PR TITLE
build: fix mingw-w64 builds with ASM enabled

### DIFF
--- a/third_party/fiat/p256_64.h
+++ b/third_party/fiat/p256_64.h
@@ -1,7 +1,7 @@
 #include <openssl/base.h>
 #include "../../crypto/internal.h"
 
-#if !defined(OPENSSL_NO_ASM) && defined(__GNUC__) && defined(__x86_64__)
+#if !defined(OPENSSL_NO_ASM) && defined(__GNUC__) && defined(__x86_64__) && !defined(__MINGW32__)
 extern "C" {
 void fiat_p256_adx_mul(uint64_t*, const uint64_t*, const uint64_t*);
 void fiat_p256_adx_sqr(uint64_t*, const uint64_t*);
@@ -175,7 +175,7 @@ static FIAT_P256_FIAT_INLINE void fiat_p256_cmovznz_u64(uint64_t* out1, fiat_p25
  *
  */
 static FIAT_P256_FIAT_INLINE void fiat_p256_mul(fiat_p256_montgomery_domain_field_element out1, const fiat_p256_montgomery_domain_field_element arg1, const fiat_p256_montgomery_domain_field_element arg2) {
-#if !defined(OPENSSL_NO_ASM) && defined(__GNUC__) && defined(__x86_64__)
+#if !defined(OPENSSL_NO_ASM) && defined(__GNUC__) && defined(__x86_64__) && !defined(__MINGW32__)
   if (CRYPTO_is_BMI1_capable() && CRYPTO_is_BMI2_capable() &&
     CRYPTO_is_ADX_capable()) {
       fiat_p256_adx_mul(out1, arg1, arg2);
@@ -489,7 +489,7 @@ static FIAT_P256_FIAT_INLINE void fiat_p256_mul(fiat_p256_montgomery_domain_fiel
  *
  */
 static FIAT_P256_FIAT_INLINE void fiat_p256_square(fiat_p256_montgomery_domain_field_element out1, const fiat_p256_montgomery_domain_field_element arg1) {
-#if !defined(OPENSSL_NO_ASM) && defined(__GNUC__) && defined(__x86_64__)
+#if !defined(OPENSSL_NO_ASM) && defined(__GNUC__) && defined(__x86_64__) && !defined(__MINGW32__)
   if (CRYPTO_is_BMI1_capable() && CRYPTO_is_BMI2_capable() &&
     CRYPTO_is_ADX_capable()) {
       fiat_p256_adx_sqr(out1, arg1);


### PR DESCRIPTION
Fixes:
```
ld.lld: error: undefined symbol: fiat_p256_adx_mul
>>> referenced by libcrypto.a(bcm.o):(fiat_p256_mul)
ld.lld: error: undefined symbol: fiat_p256_adx_sqr
>>> referenced by libcrypto.a(bcm.o):(fiat_p256_square)
```

All Windows builds use NASM. NASM sources miss the implementation for
these functions. Yet they are referenced for all GCC x86_64 builds,
which includes mingw-64.

Disable these references for mingw-64 to make the build succeed.
